### PR TITLE
Update/document include payment reference

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Description
+<!-- Briefly describe what this PR does -->
+
+## Related Issue
+<!-- Link related issues, e.g. Closes #123 -->
+
+## Changes
+- 
+
+## Testing
+<!-- How can reviewers test this? -->
+
+## Checklist
+- [ ] Tested on a Prestashop store
+- [ ] Follows Prestashop coding standards
+- [ ] Documentation updated (if needed)

--- a/src/Classes/General.php
+++ b/src/Classes/General.php
@@ -727,7 +727,8 @@ class General
     {
         $paymentMethod = [
             'value' => $payment->amount,
-            'date' => date('Y-m-d')
+            'date' => date('Y-m-d'),
+            'notes' => $payment->transaction_id ?: '',
         ];
 
         if (!empty($payment->conversion_rate)) {


### PR DESCRIPTION
## Description  
This PR introduces a pull request template and adds support for including the PrestaShop payment transaction ID in document payment notes.  

## Related Issue  
N/A  

## Changes  
- Added a PR template.  
- Included the PrestaShop payment transaction ID in document payment notes.  

## Testing  
- Generate a document for an order that contains payments with a transaction ID → the transaction ID should appear in the payment notes.  
- Generate a document for an order that contains payments without a transaction ID → the payment notes should remain unchanged.  

## Checklist  
- [x] Tested on a PrestaShop store  
- [x] Follows PrestaShop coding standards  
- [x] Documentation updated (if needed)  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Payment details now include a Notes/Reference field that displays the transaction ID when available, helping users identify and reconcile payments. The field remains blank if no reference exists.
* **Chores**
  * Added a standardized pull request template with sections for description, related issues, changes, testing, and a checklist to improve consistency in future submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->