### PR TITLE
Show at code instead of internal code

### DIFF
--- a/views/templates/admin/config.tpl
+++ b/views/templates/admin/config.tpl
@@ -155,8 +155,10 @@
                                 {l s='Select an option' mod='moloni'}
                             </option>
                             {foreach from=$moloni.configurations.exemption_reason.options item=opt}
-                                <option value='{$opt.code|escape:'html':'UTF-8'}' {if $moloni.configurations.exemption_reason.value == $opt.code} selected {/if}>
-                                    {$opt.name|escape:'html':'UTF-8'} ({$opt.code|escape:'html':'UTF-8'})
+                                {assign var="selected" value=($moloni.configurations.exemption_reason.value == $opt.code || $moloni.configurations.exemption_reason.value == $opt.at_code)}
+
+                                <option value='{$opt.code|escape:'html':'UTF-8'}' {if $selected} selected {/if}>
+                                    {$opt.name|escape:'html':'UTF-8'} ({$opt.at_code|escape:'html':'UTF-8'})
                                 </option>
                             {/foreach}
                         </select>
@@ -172,8 +174,10 @@
                                 {l s='Select an option' mod='moloni'}
                             </option>
                             {foreach from=$moloni.configurations.exemption_reason.options item=opt}
-                                <option value='{$opt.code|escape:'html':'UTF-8'}' {if $moloni.configurations.exemption_reason_shipping.value == $opt.code} selected {/if}>
-                                    {$opt.name|escape:'html':'UTF-8'} ({$opt.code|escape:'html':'UTF-8'})
+                                {assign var="selected" value=($moloni.configurations.exemption_reason_shipping.value == $opt.code || $moloni.configurations.exemption_reason_shipping.value == $opt.at_code)}
+
+                                <option value='{$opt.code|escape:'html':'UTF-8'}' {if $selected} selected {/if}>
+                                    {$opt.name|escape:'html':'UTF-8'} ({$opt.at_code|escape:'html':'UTF-8'})
                                 </option>
                             {/foreach}
                         </select>


### PR DESCRIPTION
## Description
On the selects, change the exemption reason string to start with `at_code` instead of `code`.

## Related Issue
n/a

## Changes
- Update the settings page to show the correct code.

## Testing
Check settings page and create documents with old and new exemptions (M10 for example).

## Checklist
- [x] Tested on a Prestashop store
- [x] Follows Prestashop coding standards
- [x] Documentation updated (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Admin dropdowns for “Exemption reason” and “Shipping exemption reason” now correctly select saved values, including those stored with alternate codes.

* **UI/Style**
  * Option labels in these dropdowns now display the option name with the standardized code format for clearer identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->